### PR TITLE
Docker-compose up will fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ docker run --gpus=all --shm-size 64g -p 7860:7860 -v ${HOME}/.cache:/root/.cache
 2. Build and run the container
 
 ```bash
+export BASE_MODEL='decapoda-research/llama-7b-hf'
 docker-compose up -d --build
 ```
 


### PR DESCRIPTION
blindly running docker-compose up will fail :
alpaca-lora_1  | ===================================BUG REPORT===================================
alpaca-lora_1  | Welcome to bitsandbytes. For bug reports, please submit your error trace to: https://github.com/TimDettmers/bitsandbytes/issues
alpaca-lora_1  | ================================================================================
alpaca-lora_1  | CUDA_SETUP: WARNING! libcudart.so not found in any environmental path. Searching /usr/local/cuda/lib64...
alpaca-lora_1  | CUDA SETUP: CUDA runtime path found: /usr/local/cuda/lib64/libcudart.so
alpaca-lora_1  | CUDA SETUP: Highest compute capability among GPUs detected: 8.6
alpaca-lora_1  | CUDA SETUP: Detected CUDA version 118
alpaca-lora_1  | CUDA SETUP: Loading binary /usr/local/lib/python3.10/dist-packages/bitsandbytes/libbitsandbytes_cuda118.so...
alpaca-lora_1  |   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_errors.py", line 259, in hf_raise_for_status
alpaca-lora_1  |     response.raise_for_status()
alpaca-lora_1  |   File "/usr/local/lib/python3.10/dist-packages/requests/models.py", line 1021, in raise_for_status
alpaca-lora_1  |     raise HTTPError(http_error_msg, response=self)
alpaca-lora_1  | requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://huggingface.co/True/resolve/main/tokenizer.model